### PR TITLE
Bugfix: offset() was scaling input polygon coordinates in-place

### DIFF
--- a/lib/Math/Clipper.pm
+++ b/lib/Math/Clipper.pm
@@ -49,7 +49,7 @@ sub offset {
 	my $delta = shift;
 	my $scale = @_ ? shift:100;
 	my $scalevec=[$scale,$scale];
-	my $polyscopy=[(map {[(map {[(map {$_*=$scalevec->[0]} @{$_})]} @{$_})]} @{$polygons})];
+	my $polyscopy=[(map {[(map {[(map {$_*$scalevec->[0]} @{$_})]} @{$_})]} @{$polygons})];
 	my $ret = _offset($polyscopy,$delta*$scale);
 	unscale_coordinate_sets($scalevec , $ret);
 	return $ret;


### PR DESCRIPTION
Bugfix: offset() was scaling input polygon coordinates in-place (by reference) and not unscaling them. Input shouldn't be modified instead
